### PR TITLE
Support different railway values

### DIFF
--- a/src/main/java/de/geofabrik/railway_routing/RailFlagEncoder.java
+++ b/src/main/java/de/geofabrik/railway_routing/RailFlagEncoder.java
@@ -3,6 +3,7 @@ package de.geofabrik.railway_routing;
 import static com.graphhopper.routing.util.EncodingManager.getKey;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Arrays;
 import java.util.List;
 
@@ -21,6 +22,7 @@ import de.geofabrik.railway_routing.util.MultiValueChecker;
 public class RailFlagEncoder extends AbstractFlagEncoder {
 
     public static final String NAME = "name";
+    public static final String RAILWAY = "railwayValues";
     public static final String ELECTRIFIED = "electrifiedValues";
     public static final String VOLATAGES = "acceptedVoltages";
     public static final String FREQUENCIES = "acceptedFrequencies";
@@ -33,6 +35,7 @@ public class RailFlagEncoder extends AbstractFlagEncoder {
 	protected final Integer defaultSpeed = 25;
 	private int tk;
 	private String name;
+	private HashSet<String> railwayValues;
 	private ArrayList<String> electrifiedValues;
 	private ArrayList<Integer> acceptedVoltages;
 	private ArrayList<Double> acceptedFrequencies;
@@ -80,6 +83,15 @@ public class RailFlagEncoder extends AbstractFlagEncoder {
         } else {
             this.properties.put(properties);
         }
+        // railway values
+        String railwayProps = properties.get(RAILWAY, "");
+        if (!railwayProps.equals("")) {
+            this.railwayValues = new HashSet<String>(Arrays.asList(railwayProps.split(";")));
+        } else {
+            this.railwayValues = new HashSet<String>();
+            this.railwayValues.add("rail");
+        }
+
         // electrified values
         String electrifiedProps = properties.get(ELECTRIFIED, "");
         if (!electrifiedProps.equals("")) {
@@ -164,7 +176,7 @@ public class RailFlagEncoder extends AbstractFlagEncoder {
 
     @Override
     public EncodingManager.Access getAccess(ReaderWay way) {
-        if (!way.hasTag("railway", "rail") || !hasCompatibleElectricity(way) || !hasCompatibleGauge(way)) {
+        if (!way.hasTag("railway", railwayValues) || !hasCompatibleElectricity(way) || !hasCompatibleGauge(way)) {
             return EncodingManager.Access.CAN_SKIP;
         }
         if (!acceptYardSpur && isYardSpur(way)) {

--- a/src/main/java/de/geofabrik/railway_routing/RailFlagEncoder.java
+++ b/src/main/java/de/geofabrik/railway_routing/RailFlagEncoder.java
@@ -32,25 +32,25 @@ public class RailFlagEncoder extends AbstractFlagEncoder {
     public static final String ACCEPT_YARD_SPUR = "yardSpur";
 
     protected boolean speedTwoDirections = false;
-	protected final Integer defaultSpeed = 25;
-	private int tk;
-	private String name;
-	private HashSet<String> railwayValues;
-	private ArrayList<String> electrifiedValues;
-	private ArrayList<Integer> acceptedVoltages;
-	private ArrayList<Double> acceptedFrequencies;
-	private ArrayList<Integer> acceptedGauges;
-	private double speedCorrectionFactor;
-	private boolean acceptYardSpur;
+    protected final Integer defaultSpeed = 25;
+    private int tk;
+    private String name;
+    private HashSet<String> railwayValues;
+    private ArrayList<String> electrifiedValues;
+    private ArrayList<Integer> acceptedVoltages;
+    private ArrayList<Double> acceptedFrequencies;
+    private ArrayList<Integer> acceptedGauges;
+    private double speedCorrectionFactor;
+    private boolean acceptYardSpur;
 
-	public RailFlagEncoder() {
-		this(5, 5, 0, "rail");
-	}
+    public RailFlagEncoder() {
+        this(5, 5, 0, "rail");
+    }
 
-	public RailFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts) {
-	    this(speedBits, speedFactor, maxTurnCosts, "rail");
-	    //TODO change to true if we support 
-	}
+    public RailFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts) {
+      this(speedBits, speedFactor, maxTurnCosts, "rail");
+      //TODO change to true if we support
+    }
 
     public RailFlagEncoder(PMap properties) {
         this((int) properties.getLong("speedBits", 5),
@@ -60,7 +60,7 @@ public class RailFlagEncoder extends AbstractFlagEncoder {
         this.speedTwoDirections = properties.getBool("speed_two_directions", false);
         this.properties = properties;
         initFromProperties(properties);
-	}
+    }
 
     public RailFlagEncoder(String propertiesStr) {
         this(new PMap(propertiesStr));
@@ -138,7 +138,7 @@ public class RailFlagEncoder extends AbstractFlagEncoder {
         maxPossibleSpeed = speed;
     }
 
-	@Override
+    @Override
     public long handleRelationTags(long oldRelation, ReaderRelation relation) {
         return oldRelation;
     }
@@ -193,18 +193,18 @@ public class RailFlagEncoder extends AbstractFlagEncoder {
     }
 
     protected double getSpeed(ReaderWay way) {
-    	if (way.hasTag("service", "siding")) {
-    		return 40;
-    	} else if (way.hasTag("service", "yard")) {
-    		return 25;
-    	} else if (way.hasTag("service", "crossover")) {
-    		return 60;
-    	} else if (way.hasTag("usage", "main")) {
-    		return 100;
-    	} else if (way.hasTag("usage", "branch")) {
-    		return 50;
-    	}
-		return defaultSpeed;
+        if (way.hasTag("service", "siding")) {
+            return 40;
+        } else if (way.hasTag("service", "yard")) {
+            return 25;
+        } else if (way.hasTag("service", "crossover")) {
+            return 60;
+        } else if (way.hasTag("usage", "main")) {
+            return 100;
+        } else if (way.hasTag("usage", "branch")) {
+            return 50;
+        }
+        return defaultSpeed;
     }
 
     @Override
@@ -240,31 +240,31 @@ public class RailFlagEncoder extends AbstractFlagEncoder {
     }
 
     protected int handlePriority(ReaderWay way, int priorityFromRelation) {
-    	if (way.hasTag("usage", "main")) {
-    		return 140;
-    	}
-    	if (way.hasTag("usage", "branch")) {
-        	return 70;
+        if (way.hasTag("usage", "main")) {
+            return 140;
         }
-    	if (way.hasTag("service", "siding")) {
-        	return 40;
+        if (way.hasTag("usage", "branch")) {
+            return 70;
         }
-    	if (way.hasTag("service", "crossover")) {
-        	return 20;
+        if (way.hasTag("service", "siding")) {
+            return 40;
         }
-    	if (way.hasTag("service", "yard")) {
-        	return 5;
+        if (way.hasTag("service", "crossover")) {
+            return 20;
         }
-    	if (way.hasTag("service", "spur")) {
-        	return 1;
+        if (way.hasTag("service", "yard")) {
+            return 5;
         }
-    	return 15;
+        if (way.hasTag("service", "spur")) {
+            return 1;
+        }
+        return 15;
     }
 
-	@Override
-	public int getVersion() {
-	    return 0;
-	}
+    @Override
+    public int getVersion() {
+        return 0;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/de/geofabrik/railway_routing/RailFlagEncoder.java
+++ b/src/main/java/de/geofabrik/railway_routing/RailFlagEncoder.java
@@ -95,7 +95,7 @@ public class RailFlagEncoder extends AbstractFlagEncoder {
         // electrified values
         String electrifiedProps = properties.get(ELECTRIFIED, "");
         if (!electrifiedProps.equals("")) {
-            this.electrifiedValues = new ArrayList<String>(Arrays.asList(properties.get("electrifiedValues", "").split(";")));
+            this.electrifiedValues = new ArrayList<String>(Arrays.asList(electrifiedProps.split(";")));
         } else {
             this.electrifiedValues = new ArrayList<String>();
         }

--- a/src/main/java/de/geofabrik/railway_routing/RailFlagEncoderFactory.java
+++ b/src/main/java/de/geofabrik/railway_routing/RailFlagEncoderFactory.java
@@ -70,7 +70,7 @@ public class RailFlagEncoderFactory {
         }
         return new RailFlagEncoder(properties);
     }
-    
+
     public static FlagEncoder[] createEncoders(String[] names) {
         LinkedList<FlagEncoder> encoders = new LinkedList<FlagEncoder>();
         for (String s : names) {

--- a/src/main/java/de/geofabrik/railway_routing/RailFlagEncoderFactory.java
+++ b/src/main/java/de/geofabrik/railway_routing/RailFlagEncoderFactory.java
@@ -13,6 +13,7 @@ public class RailFlagEncoderFactory {
     public static FlagEncoder createFlagEncoder(FlagEncoderConfiguration config) {
         PMap properties = new PMap();
         properties.put(RailFlagEncoder.NAME, config.getName());
+        properties.put(RailFlagEncoder.RAILWAY, config.getRailway());
         properties.put(RailFlagEncoder.ELECTRIFIED, config.getElectrified());
         properties.put(RailFlagEncoder.VOLATAGES, config.getVoltages());
         properties.put(RailFlagEncoder.FREQUENCIES, config.getFrequencies());

--- a/src/main/java/de/geofabrik/railway_routing/http/FlagEncoderConfiguration.java
+++ b/src/main/java/de/geofabrik/railway_routing/http/FlagEncoderConfiguration.java
@@ -9,6 +9,7 @@ public class FlagEncoderConfiguration {
     @NotEmpty
     private String name;
 
+    private String railway = "rail";
     private String electrified = "";
     private String voltages = "";
     private String frequencies = "";
@@ -20,6 +21,11 @@ public class FlagEncoderConfiguration {
     @JsonProperty
     public String getName() {
         return name;
+    }
+
+    @JsonProperty
+    public String getRailway() {
+        return railway;
     }
 
     @JsonProperty
@@ -61,6 +67,11 @@ public class FlagEncoderConfiguration {
     @JsonProperty
     public void setName(String value) {
         name = value;
+    }
+
+    @JsonProperty
+    public void setRailway(String value) {
+        railway = value;
     }
 
     @JsonProperty

--- a/src/main/java/de/geofabrik/railway_routing/http/RailwayRoutingApplication.java
+++ b/src/main/java/de/geofabrik/railway_routing/http/RailwayRoutingApplication.java
@@ -8,6 +8,8 @@ package de.geofabrik.railway_routing.http;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.EnumSet;
+import javax.servlet.DispatcherType;
 
 import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -21,6 +23,7 @@ import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
 import com.graphhopper.http.resources.RootResource;
+import com.graphhopper.http.CORSFilter;
 
 import io.dropwizard.Application;
 import io.dropwizard.bundles.assets.ConfiguredAssetsBundle;
@@ -54,5 +57,7 @@ public final class RailwayRoutingApplication extends Application<RailwayRoutingS
     public void run(RailwayRoutingServerConfiguration configuration, Environment environment) throws Exception {
 
         environment.jersey().register(new RootResource());
+        environment.servlets().addFilter("cors", CORSFilter.class).addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), false, "*");
+
     }
 }


### PR DESCRIPTION
Currently only railway=rail is supported. This PR adds support for configuring different allowed railway= values, e.g. tram, light_rail etc.

Also fixes some small bugs and normalizes indentation.