### PR TITLE
Modify types of railways that constitute `rail_access`

### DIFF
--- a/src/main/java/de/geofabrik/railway_routing/parsers/RailAccessParser.java
+++ b/src/main/java/de/geofabrik/railway_routing/parsers/RailAccessParser.java
@@ -1,5 +1,7 @@
 package de.geofabrik.railway_routing.parsers;
 
+import java.util.Set;
+
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.VehicleAccess;
@@ -13,6 +15,9 @@ import com.graphhopper.util.PMap;
 public class RailAccessParser extends AbstractAccessParser {
 
     public static final String DEFAULT_NAME = "rail";
+    private static final Set<String> ALLOWED_RAIL_TYPES = Set.of(
+        "rail", "light_rail", "tram", "subway", "construction", "proposed", "funicular", "monorail",
+    );
 
     public RailAccessParser(BooleanEncodedValue accessEnc) {
         super(accessEnc, TransportationMode.TRAIN);
@@ -29,7 +34,7 @@ public class RailAccessParser extends AbstractAccessParser {
         if (railway == null) {
             return WayAccess.CAN_SKIP;
         }
-        if (railway.equals("rail") || railway.equals("light_rail") || railway.equals("tram") || railway.equals("subway") || railway.equals("narrow_gauge")) {
+        if (ALLOWED_RAIL_TYPES.contains(railway)) {
             return WayAccess.WAY;
         }
         return WayAccess.CAN_SKIP;

--- a/src/main/java/de/geofabrik/railway_routing/parsers/RailAccessParser.java
+++ b/src/main/java/de/geofabrik/railway_routing/parsers/RailAccessParser.java
@@ -16,7 +16,7 @@ public class RailAccessParser extends AbstractAccessParser {
 
     public static final String DEFAULT_NAME = "rail";
     private static final Set<String> ALLOWED_RAIL_TYPES = Set.of(
-        "rail", "light_rail", "tram", "subway", "construction", "proposed", "funicular", "monorail",
+        "rail", "light_rail", "tram", "subway", "construction", "proposed", "funicular", "monorail"
     );
 
     public RailAccessParser(BooleanEncodedValue accessEnc) {


### PR DESCRIPTION
This PR modifies the `RailAccessParser` to include and exclude the various OSM Railway types that we need to consider for the Remix rail routing product. See https://paper.dropbox.com/doc/Rail-routing-types-and-appearances--CcoTAuntwCvKSa99WV5edFPyAg-K1oQPVSL3s8eXf6SLyyow for more information about what we want to include and exclude.

After this change merges, the value of `rail_access` in the various custom costing profiles will change to include everything in the Set.

This addresses https://ridewithvia.atlassian.net/browse/REM-8628

A follow up PR will be needed in the monorepo to bust the cache on the curl request made to this repo in the dockerfile